### PR TITLE
Improve user experience on the slideshow

### DIFF
--- a/root/Header/main.svelte
+++ b/root/Header/main.svelte
@@ -103,10 +103,10 @@
 
       <li>
         <a class="iconic" href={resolve('/photos')}>
-         <ImagePlay class="narrow" />
-         <span>
-           <span class="narrow">30 Years </span> Slideshow
-         </span>
+          <ImagePlay class="narrow" />
+          <span>
+            <span class="narrow">30 Years </span> Slideshow
+          </span>
         </a>
       </li>
 

--- a/root/photos/+page.server.js
+++ b/root/photos/+page.server.js
@@ -9,21 +9,24 @@ export async function load() {
   // We parse each such a file as YAML.
   const subdirs = await Promise.all(
     (await readdir(baseDir, { withFileTypes: true }))
-    .filter(entry => entry.isDirectory())
-    .map(async entry => {
-      const hasMeta = await readFile(join(baseDir, entry.name, 'meta'), 'utf-8')
-	.then(() => true)
-	.catch(() => false);
-      return hasMeta ? entry.name : null;
-    })
-  ).then(results => results.filter(Boolean));
+      .filter((entry) => entry.isDirectory())
+      .map(async (entry) => {
+        const hasMeta = await readFile(
+          join(baseDir, entry.name, 'meta'),
+          'utf-8',
+        )
+          .then(() => true)
+          .catch(() => false);
+        return hasMeta ? entry.name : null;
+      }),
+  ).then((results) => results.filter(Boolean));
 
   // Read the 'meta' YAML file for each album into JSON
   const albums = await Promise.all(
     subdirs.map(async (subdir) => {
       const raw = await readFile(join(baseDir, subdir, 'meta'), 'utf-8');
       return { subdir, ...parseYaml(raw) };
-    })
+    }),
   );
 
   // For each album, expand each of the photos it contains. The properties of
@@ -31,7 +34,7 @@ export async function load() {
   // each individual photo. This uses some extra kilobytes more memory, but
   // the code is simpler.
   const photos = albums.flatMap(({ subdir, photos = [], ...albumMeta }) =>
-    photos.map(photo => ({ subdir, ...albumMeta, ...photo }))
+    photos.map((photo) => ({ subdir, ...albumMeta, ...photo })),
   );
 
   return { photos };

--- a/root/photos/+page.svelte
+++ b/root/photos/+page.svelte
@@ -1,5 +1,4 @@
 <script>
-
   // The photo data is loaded with server-side javascript from the original
   // YAML metadata.
   let { data } = $props();
@@ -20,7 +19,7 @@
 
   // Build a lookup map from "hash key" (path) to index
   const indexByKey = Object.fromEntries(
-    photos.map((p, i) => [`${p.subdir}/${p.file}`, i])
+    photos.map((p, i) => [`${p.subdir}/${p.file}`, i]),
   );
 
   let current = $state(0);
@@ -55,7 +54,9 @@
   function startTimer() {
     clearInterval(timer);
     if (interval > 0) {
-      timer = setTimeout(() => { current = (current + 1) % photos.length; }, interval * 1000);
+      timer = setTimeout(() => {
+        current = (current + 1) % photos.length;
+      }, interval * 1000);
     }
   }
 
@@ -71,7 +72,7 @@
   }
 
   $effect(() => {
-    interval;          // depend on interval
+    interval; // depend on interval
     startTimer();
     return () => clearTimeout(timer);
   });
@@ -89,8 +90,7 @@
   let footerHeight = $state(0);
   $effect(() => {
     const footer = document.querySelector('footer');
-    if (!footer)
-      return;
+    if (!footer) return;
     const observer = new ResizeObserver(() => {
       footerHeight = footer.offsetHeight;
     });
@@ -103,7 +103,10 @@
     function handleKey(e) {
       if (e.key === 'ArrowLeft') prev();
       else if (e.key === 'ArrowRight') next();
-      else if (e.key === ' ') { e.preventDefault(); toggleSlideshow(); }
+      else if (e.key === ' ') {
+        e.preventDefault();
+        toggleSlideshow();
+      }
     }
 
     window.addEventListener('keydown', handleKey);
@@ -117,7 +120,7 @@
     if (!ready) return;
 
     // N=3 seems a good number
-    const links = [1, 2, 3].map(offset => {
+    const links = [1, 2, 3].map((offset) => {
       const photo = photos[(current + offset) % photos.length];
       const link = document.createElement('link');
       link.rel = 'preload';
@@ -127,123 +130,147 @@
       return link;
     });
 
-    return () => links.forEach(link => link.remove());
+    return () => links.forEach((link) => link.remove());
   });
-
 </script>
 
 <style>
-#photo-all {
-  align-items: center;
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  justify-content: center;
-  margin: 0;
-  padding: 0;
-  position: relative;
-  width: 100%;
-}
-
-#photo-wrapper {
-  align-items: center;
-  display: flex;
-  flex: 1;
-  height: 100%;
-  justify-content: center;
-  min-height: 0;
-  position: relative;
-}
-
-#photo {
-  display: block;
-  max-height: 100%;
-  max-width: 100%;
-}
-
-/* leave some room with margin-bottom. This moves the infobox a bit higher,
-   so that the prev/slide/next buttons don't hide it. */
-#photo-info {
-  position: relative;
-  top: auto;
-  bottom: 0;
-  width: 100%;
-  margin-bottom: 3rem;
-  min-height: 6em;
-  min-width: 20em;
-  background-color: #f5f5f5;
-  opacity: 0.9;
-  font-size: 100%;
-  padding: 0;
-}
-
-#photo-metadata {
-  position: absolute;
-  left: 0.75em;
-  top: 0.5em;
-}
-
-button.prev, button.next {
-  position: fixed;
-  bottom: 1rem;
-  z-index: 10;
-}
-
-.next-group {
-  position: fixed;
-  right: 1rem;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 0.5rem;
-  z-index: 10;
-}
-
-button.next, button.slideshow {
-  position: static;
-}
-button.prev { left: 1rem; }
-button.next { right: 1rem; }
-
-/* on narrow screens, hide the word 'slideshow'. Otherwise the button
-   is too wide */
-@media (max-width: 480px) {
-  .slideshow-long {
-    display: none;
+  #photo-all {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    justify-content: center;
+    margin: 0;
+    padding: 0;
+    position: relative;
+    width: 100%;
   }
-}
+
+  #photo-wrapper {
+    align-items: center;
+    display: flex;
+    flex: 1;
+    height: 100%;
+    justify-content: center;
+    min-height: 0;
+    position: relative;
+  }
+
+  #photo {
+    display: block;
+    max-height: 100%;
+    max-width: 100%;
+  }
+
+  /* leave some room with margin-bottom. This moves the infobox a bit higher,
+   so that the prev/slide/next buttons don't hide it. */
+  #photo-info {
+    position: relative;
+    top: auto;
+    bottom: 0;
+    width: 100%;
+    margin-bottom: 3rem;
+    min-height: 6em;
+    min-width: 20em;
+    background-color: #f5f5f5;
+    opacity: 0.9;
+    font-size: 100%;
+    padding: 0;
+  }
+
+  #photo-metadata {
+    position: absolute;
+    left: 0.75em;
+    top: 0.5em;
+  }
+
+  button.prev,
+  button.next {
+    position: fixed;
+    bottom: 1rem;
+    z-index: 10;
+  }
+
+  .next-group {
+    position: fixed;
+    right: 1rem;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+    z-index: 10;
+  }
+
+  button.next,
+  button.slideshow {
+    position: static;
+  }
+  button.prev {
+    left: 1rem;
+  }
+  button.next {
+    right: 1rem;
+  }
+
+  /* on narrow screens, hide the word 'slideshow'. Otherwise the button
+   is too wide */
+  @media (max-width: 480px) {
+    .slideshow-long {
+      display: none;
+    }
+  }
 </style>
 
 <section class="slideshow">
   <!-- this is the "prev" button -->
-  <button class="prev" style="bottom: {footerHeight + 16}px" onclick={prev}>← Previous</button>
+  <button class="prev" style="bottom: {footerHeight + 16}px" onclick={prev}
+    >← Previous</button
+  >
 
   <!--
     We don't display the photo until the metadata files have been loaded and shuffled.
     Moreover, the timeout to move to the next photo is only set once the photo is loaded.
   -->
   {#if ready}
-  <div id="photo-all">
-    <div id="photo-wrapper">
-      <img id="photo"
-           src={`${mediaBase}/${photos[current].subdir}/${photos[current].file}`}
-           alt={photos[displayed].title}
-           onload={() => { displayed = current; startTimer(); }} />
-    </div>
+    <div id="photo-all">
+      <div id="photo-wrapper">
+        <img
+          id="photo"
+          src={`${mediaBase}/${photos[current].subdir}/${photos[current].file}`}
+          alt={photos[displayed].title}
+          onload={() => {
+            displayed = current;
+            startTimer();
+          }}
+        />
+      </div>
 
-    <!-- the photo and description go here -->
-    <div id="photo-info">
-      <div id="photo-metadata">
-        {#if photos[displayed].url}
-        <a id="gallery-title" href={photos[displayed].url}>{photos[displayed].title}</a>
-        {:else}
-        <span id="gallery-title">{photos[displayed].title}</span>
-        {/if}{#if photos[displayed].city}, in {photos[displayed].city}{/if}
-        <div style="font-size: 90%"><span id="author">{photos[displayed].author}</span>{#if photos[displayed].year}, <span id="year">{photos[displayed].year}</span>{/if}</div>
-        <div style="font-size: 90%"><span id="license">{photos[displayed].license}</span></div>
-      </div>    <!-- photo-metadata -->
-    </div>      <!-- photo-info -->
-  </div>        <!-- photo-all -->
+      <!-- the photo and description go here -->
+      <div id="photo-info">
+        <div id="photo-metadata">
+          {#if photos[displayed].url}
+            <a id="gallery-title" href={photos[displayed].url}
+              >{photos[displayed].title}</a
+            >
+          {:else}
+            <span id="gallery-title">{photos[displayed].title}</span>
+          {/if}{#if photos[displayed].city}, in {photos[displayed].city}{/if}
+          <div style="font-size: 90%">
+            <span id="author">{photos[displayed].author}</span
+            >{#if photos[displayed].year}, <span id="year"
+                >{photos[displayed].year}</span
+              >{/if}
+          </div>
+          <div style="font-size: 90%">
+            <span id="license">{photos[displayed].license}</span>
+          </div>
+        </div>
+        <!-- photo-metadata -->
+      </div>
+      <!-- photo-info -->
+    </div>
+    <!-- photo-all -->
   {/if}
 
   <!-- the other two buttons, with all and shrinking "start/stop" button, are here -->
@@ -252,18 +279,20 @@ button.next { right: 1rem; }
       {interval > 0 ? 'Stop' : 'Start'}
       <span class="slideshow-long"> slideshow</span>
       <input
-          id="slideshow_interval"
-          type="number"
-          min="0"
-          step="0.5"
-          value={interval}
-          style="width: 3em; text-align: right"
-          onclick={(e) => e.stopPropagation()}
-          onchange={(e) => { e.stopPropagation(); interval = e.target.valueAsNumber; }}
-          />
+        id="slideshow_interval"
+        type="number"
+        min="0"
+        step="0.5"
+        value={interval}
+        style="width: 3em; text-align: right"
+        onclick={(e) => e.stopPropagation()}
+        onchange={(e) => {
+          e.stopPropagation();
+          interval = e.target.valueAsNumber;
+        }}
+      />
     </button>
 
     <button class="next" onclick={next}>Next →</button>
   </div>
-
 </section>

--- a/root/photos/+page.svelte
+++ b/root/photos/+page.svelte
@@ -10,6 +10,7 @@
 
   // Svelte doesn't like the way we reference `data` here, but in our case
   // it doesn't change after load, so ignore that warning.
+  // svelte-ignore state_referenced_locally
   const photos = [...data.photos];
   // This is apparently called a "Fisher-Yates" shuffle.
   for (let i = photos.length - 1; i > 0; i--) {
@@ -44,15 +45,37 @@
   // and next buttons, which automatically stop the slideshow when clicked.
   // There's also a start/stop button that can be used to toggle the state, and
   // the time between one load and the next can be set in a text box.
+  // We want to start the timer on each photo's onload(), so that each photo is on
+  // display at least during 'interval'.  It might be longer if the next photo is
+  // large, but that beats having the next photo disappear almost immediately.
   let interval = $state(3);
+  let savedInterval = $state(3);
   let timer;
-  $effect(() => {
+
+  function startTimer() {
     clearInterval(timer);
     if (interval > 0) {
-      timer = setInterval(() => { current = (current + 1) % photos.length; }, interval * 1000);
+      timer = setTimeout(() => { current = (current + 1) % photos.length; }, interval * 1000);
     }
-    return () => clearInterval(timer);
+  }
+
+  // Save the current interval when the slideshow is turned off, and restore
+  // to that value when it is restarted.
+  function toggleSlideshow() {
+    if (interval > 0) {
+      savedInterval = interval;
+      interval = 0;
+    } else {
+      interval = savedInterval;
+    }
+  }
+
+  $effect(() => {
+    interval;          // depend on interval
+    startTimer();
+    return () => clearTimeout(timer);
   });
+
   function prev() {
     interval = 0;
     current = (current - 1 + photos.length) % photos.length;
@@ -80,11 +103,31 @@
     function handleKey(e) {
       if (e.key === 'ArrowLeft') prev();
       else if (e.key === 'ArrowRight') next();
-      else if (e.key === ' ') { e.preventDefault(); interval = interval > 0 ? 0 : 3; }
+      else if (e.key === ' ') { e.preventDefault(); toggleSlideshow(); }
     }
 
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
+  });
+
+  // Add <link preload> to preload the next N photos.  This avoids having to
+  // wait the CDN too frequently.  But remove previous preloads to avoid using
+  // excessive browser memory.
+  $effect(() => {
+    if (!ready) return;
+
+    // N=3 seems a good number
+    const links = [1, 2, 3].map(offset => {
+      const photo = photos[(current + offset) % photos.length];
+      const link = document.createElement('link');
+      link.rel = 'preload';
+      link.as = 'image';
+      link.href = `${mediaBase}/${photo.subdir}/${photo.file}`;
+      document.head.appendChild(link);
+      return link;
+    });
+
+    return () => links.forEach(link => link.remove());
   });
 
 </script>
@@ -175,14 +218,17 @@ button.next { right: 1rem; }
   <!-- this is the "prev" button -->
   <button class="prev" style="bottom: {footerHeight + 16}px" onclick={prev}>← Previous</button>
 
-  <!-- we don't display the photo until the metadata files have been loaded and shuffled -->
+  <!--
+    We don't display the photo until the metadata files have been loaded and shuffled.
+    Moreover, the timeout to move to the next photo is only set once the photo is loaded.
+  -->
   {#if ready}
   <div id="photo-all">
     <div id="photo-wrapper">
       <img id="photo"
            src={`${mediaBase}/${photos[current].subdir}/${photos[current].file}`}
            alt={photos[displayed].title}
-           onload={() => displayed = current} />
+           onload={() => { displayed = current; startTimer(); }} />
     </div>
 
     <!-- the photo and description go here -->
@@ -202,7 +248,7 @@ button.next { right: 1rem; }
 
   <!-- the other two buttons, with all and shrinking "start/stop" button, are here -->
   <div class="next-group" style="bottom: {footerHeight + 16}px">
-    <button class="slideshow" onclick={() => interval = interval > 0 ? 0 : 3}>
+    <button class="slideshow" onclick={toggleSlideshow}>
       {interval > 0 ? 'Stop' : 'Start'}
       <span class="slideshow-long"> slideshow</span>
       <input


### PR DESCRIPTION
- preload two photos. This avoids waiting for the photo to load too frequently.
- start the timer on each photo .onload rather than having it be continuous.  This way, each photo is displayed at least the amount of time specified by the interval; this is visible if the next photo is large: it's skipped way too soon.  Also, if the timeout is very short (0.01 or so) then you see the URLs change but no photo is displayed.
- On slideshow stop/restart, preserve the interval specified by the user, in case they changed from the default.